### PR TITLE
Update kernel boot argument in  build_image.sh

### DIFF
--- a/src_e1000/build_image.sh
+++ b/src_e1000/build_image.sh
@@ -42,7 +42,7 @@ qemu-system-x86_64 \
 -device "e1000,netdev=eth0" \
 -object "filter-dump,id=eth0,netdev=eth0,file=dump.dat" \
 -kernel $kernel_image \
--append "root=/dev/ram rdinit=sbin/init ip=10.0.2.15::10.0.2.1:255.255.255.0 console=ttyS0" \
+-append "root=/dev/ram rdinit=sbin/init ip=10.0.2.15::10.0.2.1:255.255.255.0 console=ttyS0 no_timer_check" \
 -nographic \
 -initrd $rootfs_img
 


### PR DESCRIPTION
Add "no_timer_check" argument in kernel boot cmd line. Avoid QEMU kernel panic at boot time.
See https://lore.kernel.org/all/20200402093132.GA15839@Red/T/ for more information.